### PR TITLE
Updated Rails gem to '3.2.11'. Patches: CVE-2013-0155 and CVE-2013-0156

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rails', '3.2.3'
+gem 'rails', '3.2.11'
 gem 'bootstrap-sass', '2.0.0'
 gem 'bcrypt-ruby', '3.0.1'
 gem 'faker', '1.0.1'


### PR DESCRIPTION
Updated Rails gem to '3.2.11'. Patches: CVE-2013-0155 and CVE-2013-0156
